### PR TITLE
sign previews and show a few more types

### DIFF
--- a/app/components/files/type-document.js
+++ b/app/components/files/type-document.js
@@ -1,15 +1,34 @@
 import Ember from 'ember';
 import ajax from 'ic-ajax';
+import pathSignature from '../../lib/path-signature';
 
 export default Ember.Component.extend({
+  showingPreview: Ember.computed.not('model.isLarge'),
+
   didInsertElement(){
     if(!this.get('canSandbox')) { return; }
-    ajax(this.get('model.rawPath')).then((response) => {
-      this.set('srcDoc', response);
+
+    if(this.get('showingPreview')) {
+      this.getSrcDoc();
+    }
+  },
+
+  getSrcDoc: function() {
+    pathSignature(this.get('model.rawPath')).then((path) => {
+      ajax(path).then((response) => {
+        this.set('srcDoc', response);
+      });
     });
   },
 
   canSandbox: function() {
     return "sandbox" in document.createElement("iframe");
-  }.property()
+  }.property(),
+
+  actions: {
+    showPreview: function() {
+      this.set('showingPreview', true);
+      this.getSrcDoc();
+    }
+  }
 });

--- a/app/components/files/type-html.js
+++ b/app/components/files/type-html.js
@@ -1,0 +1,11 @@
+import typeDocument from './type-document';
+
+export default typeDocument.extend({
+  viewingSource: false,
+
+  actions: {
+    toggleSource: function() {
+      this.toggleProperty('viewingSource');
+    }
+  }
+});

--- a/app/components/files/type-pdf.js
+++ b/app/components/files/type-pdf.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+import pathSignature from '../../lib/path-signature';
+
+export default Ember.Component.extend({
+  src: null,
+
+  didInsertElement() {
+    pathSignature(this.get('model.rawPath')).then((path) => {
+      this.set('src', path);
+    });
+  }
+});

--- a/app/helpers/escape-html.js
+++ b/app/helpers/escape-html.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export function escapeHtml(params) {
+  return Ember.Handlebars.Utils.escapeExpression(params);
+}
+
+export default Ember.Helper.helper(escapeHtml);

--- a/app/lib/filetype-icons.js
+++ b/app/lib/filetype-icons.js
@@ -6,6 +6,7 @@ export default {
   audio: 'music-note',
   markdown: 'code',
   pdf: 'insert-drive-file',
+  html: 'insert-drive-file',
   document: 'insert-drive-file',
   'default-type': 'crop-portrait'
 };

--- a/app/lib/filetypes.js
+++ b/app/lib/filetypes.js
@@ -12,13 +12,15 @@ export default {
   'aac': 'audio',
   'pdf': 'pdf',
   'md': 'markdown',
-  'htm': 'document',
-  'html': 'document',
+  'htm': 'html',
+  'html': 'html',
   'xml': 'document',
   'cf': 'document',
   'conf': 'document',
   'config': 'document',
   'nfo': 'document',
   'txt': 'document',
+  'csv': 'document',
+  'tsv': 'document',
   'defaultType': 'default-type'
 };

--- a/app/lib/path-signature.js
+++ b/app/lib/path-signature.js
@@ -1,7 +1,8 @@
 import ajax from 'ic-ajax';
 
 export default function(path) {
-  return ajax('/api/signature').then((response) => {
+  let encodedPath = path.replace(/\s/g, '%20');
+  return ajax('/api/signature', {data: {path: encodedPath}}).then((response) => {
     response = JSON.parse(response);
     return `${path}?signature=${response.signature}`;
   });

--- a/app/lib/path-signature.js
+++ b/app/lib/path-signature.js
@@ -1,0 +1,8 @@
+import ajax from 'ic-ajax';
+
+export default function(path) {
+  return ajax('/api/signature').then((response) => {
+    response = JSON.parse(response);
+    return `${path}?signature=${response.signature}`;
+  });
+}

--- a/app/models/file.js
+++ b/app/models/file.js
@@ -39,6 +39,10 @@ export default Ember.Object.extend(Webdav, {
     return !this.get('isDirectory');
   }.property('isDirectory'),
 
+  isLarge: function() {
+    return this.get('size') > 2 * 1024 * 1024;
+  }.property('size'),
+
   extension: function() {
     var pieces = this.get('name').split('.');
     if(pieces.length > 1) {

--- a/app/styles/file.scss
+++ b/app/styles/file.scss
@@ -48,8 +48,15 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    position: relative;
 
     background-color: #000;
+
+    .view-source {
+      position: absolute;
+      top: -50px;
+      right: 0;
+    }
 
     audio, .no-preview {
       width: 100%;
@@ -71,11 +78,12 @@
       margin: auto;
     }
 
-    iframe, object {
+    iframe, object, pre {
       width: 100%;
       align-self: stretch;
       background-color: #FFF;
       border: 0;
+      margin: 0;
     }
 
     .markdown {

--- a/app/templates/components/files/type-document.hbs
+++ b/app/templates/components/files/type-document.hbs
@@ -1,5 +1,9 @@
-{{#if canSandbox}}
-  <iframe srcdoc="{{srcDoc}}" sandbox="allow-scripts"></iframe>
+{{#if showingPreview}}
+  {{#if canSandbox}}
+    <iframe srcdoc="<pre>{{escapeHtml srcDoc}}</pre>" sandbox=""></iframe>
+  {{else}}
+    <p>Your browser doesn't support sandboxing, so we can't show a preview inline.</p>
+  {{/if}}
 {{else}}
-  <p>Your browser doesn't support sandboxing, so we can't show a preview inline.</p>
+  {{#paper-button raised=true action="showPreview"}}Show Preview ({{filesize model.size}}){{/paper-button}}
 {{/if}}

--- a/app/templates/components/files/type-html.hbs
+++ b/app/templates/components/files/type-html.hbs
@@ -1,0 +1,19 @@
+<div class="view-source">
+  {{#paper-button action="toggleSource"}}
+    {{#if viewingSource}}
+      View Rendered
+    {{else}}
+      View Source
+    {{/if}}
+  {{/paper-button}}
+</div>
+
+{{#if canSandbox}}
+  {{#if viewingSource}}
+    <iframe srcdoc="<pre>{{escapeHtml srcDoc}}</pre>" sandbox="allow-scripts"></iframe>
+  {{else}}
+    <iframe srcdoc="{{srcDoc}}" sandbox="allow-scripts"></iframe>
+  {{/if}}
+{{else}}
+  <p>Your browser doesn't support sandboxing, so we can't show a preview inline.</p>
+{{/if}}

--- a/app/templates/components/files/type-pdf.hbs
+++ b/app/templates/components/files/type-pdf.hbs
@@ -1,3 +1,7 @@
-<object data="{{model.rawPath}}" type="application/pdf">
-  <embed src="{{model.rawPath}}" type="application/pdf" />
-</object>
+{{#if src}}
+  <object data="{{src}}" type="application/pdf">
+    <embed src="{{src}}" type="application/pdf" />
+  </object>
+{{else}}
+  <p>Fetching preview...</p>
+{{/if}}

--- a/server/dav/safe-gets.js
+++ b/server/dav/safe-gets.js
@@ -1,4 +1,5 @@
 var jsDAV_ServerPlugin = require("jsdav/lib/DAV/plugin");
+var signature = require("../signature");
 
 var jsDAV_SafeGets_Plugin = module.exports = jsDAV_ServerPlugin.extend({
   name: "safe-gets",
@@ -21,6 +22,10 @@ var jsDAV_SafeGets_Plugin = module.exports = jsDAV_ServerPlugin.extend({
     return e.next();
   },
 
+  isSigned: function(req) {
+    return req.query.signature && signature.verify(req.query.signature);
+  },
+
   // HTML files should not be displayed inside davros' UI; download them instead
   setContentDisposition: function(req, res) {
     var self = this;
@@ -39,7 +44,7 @@ var jsDAV_SafeGets_Plugin = module.exports = jsDAV_ServerPlugin.extend({
       headers['content-security-policy'] = "script-src 'self'; img-src 'self'; sandbox allow-forms allow-scripts;";
 
       // exception for pdf since we want to display it inline
-      if(!self.safeTypes[headers['content-type']]) {
+      if(!self.isSigned(req)) {
         headers['content-disposition'] = 'attachment; filename=';
       }
 

--- a/server/dav/safe-gets.js
+++ b/server/dav/safe-gets.js
@@ -23,7 +23,7 @@ var jsDAV_SafeGets_Plugin = module.exports = jsDAV_ServerPlugin.extend({
   },
 
   isSigned: function(req) {
-    return req.query.signature && signature.verify(req.query.signature);
+    return req.query.signature && signature.verify(req.query.signature, req.url);
   },
 
   // HTML files should not be displayed inside davros' UI; download them instead

--- a/server/index.js
+++ b/server/index.js
@@ -41,6 +41,9 @@ module.exports = function(app, options) {
   app.post('/api/publish', publishing.publish);
   app.post('/api/unpublish', publishing.unpublish);
 
+  app.use('/previewers', signature.check());
+  app.use('/previewers', express.static('previewers'));
+
   app.get('/changelog', changelog);
 
 };

--- a/server/index.js
+++ b/server/index.js
@@ -12,6 +12,8 @@ var api    = require('./api');
 var apiWs  = require('./api-ws');
 var dav    = require('./dav');
 var morgan = require('morgan');
+var express = require('express');
+var signature = require('./signature');
 var publishing = require('./publishing');
 var sandstormPermissions = require('./sandstorm_permissions');
 var changelog = require('./changelog');
@@ -33,6 +35,7 @@ module.exports = function(app, options) {
 
   var uploadServer = api.upload(davServer);
   app.use('/api/upload', uploadServer);
+  app.use('/api/signature', signature.get());
 
   app.get('/api/publish/info', publishing.getInfo);
   app.post('/api/publish', publishing.publish);

--- a/server/signature.js
+++ b/server/signature.js
@@ -1,0 +1,54 @@
+var crypto = require('crypto');
+var url = require('url');
+
+// Keep up to two secrets, the old and the new one. Rotate them out periodically.
+var secrets = [];
+var currentSecret;
+
+function generateSecret() {
+  var secret = crypto.randomBytes(64).toString('hex');
+  currentSecret = secret;
+  secrets.unshift(secret);
+  if(secrets.length > 2) { secrets.pop(); }
+}
+
+setTimeout(generateSecret, 10 * 60 * 1000);
+generateSecret();
+
+exports.create = function(d) {
+  var hmac = crypto.createHmac('sha256', currentSecret);
+  hmac.update(d.toString());
+  return [d, hmac.digest('hex')].join('-');
+};
+
+exports.verify = function(check) {
+  var parts = check.split("-");
+  var date = parts[0], signature = parts[1];
+
+  for(var i = 0; i < secrets.length; i++) {
+    if(check === exports.create(date)) { return true; }
+  }
+  return false;
+};
+
+exports.get = function() {
+  return function get(req, res, next) {
+    var signature = exports.create((new Date()).getTime());
+
+    console.log(signature);
+    res.writeHead(200, {});
+    res.end(JSON.stringify({signature: signature}));
+  };
+};
+
+exports.check = function() {
+  return function check(req, res, next) {
+    var query = url.parse(req.url, true).query;
+    if(exports.verify(query.signature)) {
+      next();
+    } else {
+      res.writeHead(400, {});
+      res.end("Missing or invalid signature: " + query.signature);
+    }
+  };
+};

--- a/tests/unit/helpers/escape-html-test.js
+++ b/tests/unit/helpers/escape-html-test.js
@@ -1,0 +1,10 @@
+import { escapeHtml } from '../../../helpers/escape-html';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | escape html');
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let result = escapeHtml([42]);
+  assert.ok(result);
+});


### PR DESCRIPTION
- http get requests to webdav without a ?signature param will have Content-Disposition: attachment headers appended to them so that they cannot be shown inline
- add an option to toggle html sources
- display non-html documents as raw rather than as html
- large documents now prompt for preview so that they don't overload the browser

The issue we're trying to solve is that we don't want a rogue file to somehow be displayed within a grain and have the ability to modify its contents. Most of the attack surface is around the preview. These fall into a few categories:
- types that can be shown inline (image, video, audio, plaintext that is html-escaped)
- types that are absolutely unsafe and need to be sandboxed (html)
- types that can be safely rendered into the browser, but we don't necessarily trust that the renderer doesn't have defects (pdf, doc, epub)

We protect against someone just linking directly to the raw file by using the Content-Disposition method. But this also prevents setting the iframe as the src, since it just prompts the user to download it. In newer browsers, iframes have a `sandbox` attribute that can prevent the content from running in the context of the original domain. So we need to make sure 1) the browser supports sandboxing, and 2) that the page is actually inside of an iframe.

We can trivially check for the presence of sandboxing support, but unfortunately the browser does not communicate to the server that it is loaded from within an iframe. (`X-Frame-Options` headers can prevent pages from loading inside iframes, but cannot require pages load inside iframes) So we need some help from the server.

Any time we want to show iframed content, we make an ajax `/api/signature` request to the server. The server gives us back a token, and we append that token as a `?signature` query param. When we make the iframe request, the server looks for the presence of the `?signature` query param and validates that it is correct.

The server generates a token by taking the current date as an integer, signing it with hmac using its secret, appending the date and signature together and returning it to the frontend. The server generates a secret when it starts, and every 5 minutes thereafter. It accepts signatures signed with the last two secrets, so a signature is good for between 5 and 10 minutes, depending on when it was generated. Since the iframe is displayed immediately after requesting the token, there hopefully shouldn't be an issue with the signatures expiring too soon.

The server could generate the signature from the path as well, but I couldn't think of a reason why a signature would need to be for a specific path to prevent xss attacks.

This approach also relies on there only ever being one node process running, which is fine for now but could present problems if Sandstorm ever changed to allow grains to run on multiple nodes at once.
