### PR TITLE
add missing dependencies and fix lowercase jsdav imports

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,7 @@
     "pretender": "git://github.com/mnutt/pretender.git#6bef68069d90"
   },
   "resolutions": {
-    "ember": "2.2.0"
+    "ember": "2.2.0",
+    "loader.js": "3.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "bower": "^1.7.9",
     "broccoli-asset-rev": "^2.2.0",
     "ember-ajax": "0.7.1",
     "ember-cli": "^2.2.0-beta.3",
@@ -45,15 +46,17 @@
     "ember-paper": "git://github.com/mnutt/ember-paper.git#3a2605c",
     "ember-plupload": "1.13.12",
     "ember-websockets": "1.2.3",
-    "glob": "^4.5.3"
+    "glob": "^4.5.3",
+    "loader.js": "^4.0.3"
   },
   "dependencies": {
+    "archiver": "^1.0.0",
     "async": "1.4.2",
     "asyncjs": "git://github.com/fjakobs/async.js.git#bd61b6ae2cd7",
     "concat-files": "^0.1.0",
     "dirStat": "0.0.2",
-    "express": "^4.13.1",
     "ember-resolver": "^2.0.3",
+    "express": "^4.13.1",
     "jsDAV": "git://github.com/mnutt/jsDAV.git#a1a7f9f90a17",
     "jsonapi-serializer": "^1.0.4",
     "mkdirp": "0.5.1",

--- a/server/dav/notify.js
+++ b/server/dav/notify.js
@@ -1,4 +1,4 @@
-var jsDAV_ServerPlugin = require("jsdav/lib/DAV/plugin");
+var jsDAV_ServerPlugin = require("jsDAV/lib/DAV/plugin");
 var apiWs = require('../api-ws');
 var path = require('path');
 

--- a/server/dav/root-delete.js
+++ b/server/dav/root-delete.js
@@ -1,7 +1,7 @@
 var Fs = require('fs');
 
-var jsDAV_ServerPlugin = require("jsdav/lib/DAV/plugin");
-var Util               = require("jsdav/lib/shared/util");
+var jsDAV_ServerPlugin = require("jsDAV/lib/DAV/plugin");
+var Util               = require("jsDAV/lib/shared/util");
 
 var jsDAV_Notify_Plugin = module.exports = jsDAV_ServerPlugin.extend({
   name: "root-delete",

--- a/server/dav/safe-gets.js
+++ b/server/dav/safe-gets.js
@@ -1,4 +1,4 @@
-var jsDAV_ServerPlugin = require("jsdav/lib/DAV/plugin");
+var jsDAV_ServerPlugin = require("jsDAV/lib/DAV/plugin");
 
 var jsDAV_SafeGets_Plugin = module.exports = jsDAV_ServerPlugin.extend({
   name: "safe-gets",


### PR DESCRIPTION
While trying to set up davros for local development, I hit the following issues which this PR fixes:

----

**from the app log:**

Missing dist/index.html; run `ember build` to generate it.

----

    $ ember build

^ requires `bower install`
(added to package.json)

----

    $ bower install

^ required disambiguation for loader.js

----

    $ ember build
    The loader.js addon is missing from your project, please add it to `package.json`.

(added to package.json as devDependency. should it be a runtime dependency?)

----

**app logs again:**

Error: Cannot find module 'jsdav/lib/DAV/plugin'

The capitalization threw me for a while (it should be `jsDAV`). I'm pretty stumped at how this works currently - maybe it works on a mac (I'm on linux)? But it's all running on a linux VM anyway...
