### PR TITLE
add Download (zip) directory menu option

### DIFF
--- a/app/routes/file.js
+++ b/app/routes/file.js
@@ -80,6 +80,12 @@ export default Ember.Route.extend({
       $("#upload-placeholder").click();
     },
 
+    downloadDirectory: function() {
+      var path = this.get('controller.model.path');
+      var endpoint = "/api/archive?path=" + encodeURIComponent(path);
+      document.location.href = endpoint;
+    },
+
     uploadFile: function (file) {
       var source = file.file.getSource();
       var location = document.location.pathname;

--- a/app/templates/directory-menu.hbs
+++ b/app/templates/directory-menu.hbs
@@ -24,6 +24,11 @@
       {{paper-icon icon="photo" class="md-menu-align-target"}}
     {{/paper-menu-item}}
 
+    {{#paper-menu-item action="downloadDirectory" id="menu-download-directory"}}
+      <p class="label">Download (zip)</p>
+      {{paper-icon icon="file-download" class="md-menu-align-target"}}
+    {{/paper-menu-item}}
+
     {{#if canEdit}}
       {{#paper-menu-item class="danger" action="delete"}}
         <p class="label">Delete Directory</p>

--- a/server/index.js
+++ b/server/index.js
@@ -34,6 +34,7 @@ module.exports = function(app, options) {
   var uploadServer = api.upload(davServer);
   app.use('/api/upload', uploadServer);
 
+  app.get('/api/archive', api.downloadDirectory(root));
   app.get('/api/publish/info', publishing.getInfo);
   app.post('/api/publish', publishing.publish);
   app.post('/api/unpublish', publishing.unpublish);


### PR DESCRIPTION
Fixes #45 

Adds a "Download (zip)" menu item for each directory. Performs validation against odd path components (like `..`), but not safe against e.g. symlinks which point to files outside of the davros file store. As discussed in #45, this shouldn't pose a security risk (since users who can upload files can also just download the whole grain, and nothing sensitive is stored on the grain's container).

I was confused that this diff doesn't change package.json - my apologies, it looks like the `archiver` dependency accidentally snuck in as part of #46.