### PR TITLE
Second try at fixing up path encoding

### DIFF
--- a/app/components/path-breadcrumb.js
+++ b/app/components/path-breadcrumb.js
@@ -22,7 +22,7 @@ export default class PathBreadcrumbComponent extends Component {
       }
 
       const part = {
-        name: pieces[i],
+        name: decodeURIComponent(pieces[i]),
         path: path
       };
 

--- a/app/controllers/file.js
+++ b/app/controllers/file.js
@@ -19,6 +19,7 @@ export default class FileController extends Controller {
 
     let location = document.location.pathname;
     let path = file.blob.webkitRelativePath || file.fullPath || file.name;
+    path = encodeURIComponent(path);
 
     if (location.indexOf('/files') === 0) {
       // if user is in a directory, upload the files there
@@ -67,7 +68,7 @@ export default class FileController extends Controller {
   newDirectory(dirname) {
     const { model } = this;
 
-    const fullPath = [model.rawPath, dirname].join('/');
+    const fullPath = [model.rawPath, encodeURIComponent(dirname)].join('/');
 
     return fetch(fullPath, { method: 'MKCOL' }).then(() => {
       return File.load(model.path);

--- a/app/lib/webdav.js
+++ b/app/lib/webdav.js
@@ -65,7 +65,7 @@ export default class WebdavClient {
   }
 
   mkcol(path) {
-    return fetch(this.fullPath(path), {
+    return fetch(this.fullPath(encodeURIComponent(path)), {
       method: 'MKCOL'
     }).catch(function(err) {
       // eslint-disable-next-line no-console
@@ -89,7 +89,6 @@ export default class WebdavClient {
     let path = doc.querySelector('d\\:href, href').textContent;
     path = path.slice(this.base.length + 1).replace(/\/$/, '');
     let isDirectory = doc.querySelectorAll('d\\:collection, collection').length > 0;
-    path = decodeURIComponent(path);
 
     const props = {};
     for (let name of propnames) {

--- a/app/models/file.js
+++ b/app/models/file.js
@@ -67,7 +67,7 @@ export default class File {
   }
 
   get name() {
-    return this.path.split(/[\\/]/).pop();
+    return decodeURIComponent(this.path.split(/[\\/]/).pop());
   }
 
   get sortedFiles() {

--- a/app/routes/file.js
+++ b/app/routes/file.js
@@ -43,84 +43,12 @@ export default class FileRoute extends Route {
   }
 
   async reload() {
-    const newModelAttrs = await File.load(this.context.path);
+    const newModelAttrs = await File.load(this.context && this.context.path);
     this.context.files = newModelAttrs.files;
   }
 
   model(params) {
     const path = params.path || '';
     return File.load(path);
-  }
-
-  @task({
-    maxConcurrency: 5,
-    enqueue: true
-  })
-  *uploadFile(file) {
-    if (file.blob.type === '') {
-      yield;
-    } // it's a directory
-
-    let location = document.location.pathname;
-    let path = file.blob.webkitRelativePath || file.fullPath || file.name;
-
-    if (location.indexOf('/files') === 0) {
-      // if user is in a directory, upload the files there
-      location = location.replace(/^\/files\//, '');
-      // dirname of current path, so if path is /foo/README, use /foo/
-      location = location.replace(/\/[^/]*$/, '');
-    } else {
-      // otherwise, upload files in the root directory
-      // (this shouldn't happen anymore)
-      location = '';
-    }
-
-    if (path[0] !== '/') {
-      path = '/' + path;
-    }
-
-    var fullPath = [location, path].join('');
-
-    yield File.ensureCollectionExists(fullPath).then(() => {
-      return file
-        .upload('/api/upload', {
-          data: {
-            destination: fullPath
-          }
-        })
-        .then(() => {
-          return this.reload();
-        });
-    });
-  }
-
-  @action
-  delete() {
-    const { model } = this.controller;
-    const { parent } = model;
-
-    return model.remove().then(() => {
-      if (parent) {
-        this.transitionTo('file', parent);
-      } else {
-        this.transitionTo('files');
-      }
-    });
-  }
-
-  @action
-  newDirectory(dirname) {
-    const { model } = this.controller;
-
-    const fullPath = [model.rawPath, dirname].join('/');
-
-    return fetch(fullPath, { method: 'MKCOL' }).then(() => {
-      return File.load(model.path);
-    });
-  }
-
-  @action
-  upload(file) {
-    this.uploadFile.perform(file);
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "fs-promise": "^2.0.3",
     "image-size": "^1.0.0",
     "imagemagick-stream": "^4.1.1",
-    "jsDAV": "https://github.com/mnutt/jsDAV.git#a2b55b1",
+    "jsDAV": "https://github.com/mnutt/jsDAV.git#0dd810e",
     "mkdirp": "^1.0.4",
     "morgan": "^1.10.0",
     "multiparty": "^4.2.2",

--- a/server/dav/notify.js
+++ b/server/dav/notify.js
@@ -26,7 +26,7 @@ var jsDAV_Notify_Plugin = (module.exports = jsDAV_ServerPlugin.extend({
       if (directory == '.') {
         directory = '/';
       }
-      apiWs.notify(directory);
+      apiWs.notify(encodeURI(directory).replace(/#/g, '%23').replace(/\?/g, '%3F'));
     }
 
     return e.next();

--- a/yarn.lock
+++ b/yarn.lock
@@ -7732,9 +7732,9 @@ js-yaml@^3.13.1, js-yaml@^3.14.0, js-yaml@^3.2.5, js-yaml@^3.2.7:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-"jsDAV@https://github.com/mnutt/jsDAV.git#a2b55b1":
+"jsDAV@https://github.com/mnutt/jsDAV.git#0dd810e":
   version "0.3.4"
-  resolved "https://github.com/mnutt/jsDAV.git#a2b55b12f5b517d794e8f56814e2bf9eb3d69782"
+  resolved "https://github.com/mnutt/jsDAV.git#0dd810e88e0408330c4bfa72102dd10d245f4278"
   dependencies:
     asyncjs "https://github.com/mnutt/async.js.git#ad52b32"
     busboy "0.3.1"


### PR DESCRIPTION
There are lots of places that get varying encoding:

- server filesystem: not encoded
- jsdav: should be encoded (was partially encoded, this now also encodes `?` and `#`)
- front-end webdav parsing: should be encoded
- front-end navigation: should be encoded
- front-end display: not encoded

Before this, jsdav was producing `PROPFIND` results with hrefs that were not valid (contained files with unencoded `?` and `#` in the name)

Verified this works via web UI and OwnCloud direct (have not testedsandstorm yet, but don't anticipate any issues there)