### PR TITLE
Update "create new" action

### DIFF
--- a/.sandstorm/sandstorm-pkgdef.capnp
+++ b/.sandstorm/sandstorm-pkgdef.capnp
@@ -27,7 +27,7 @@ const pkgdef :Spk.PackageDefinition = (
 
     actions = [
       # Define your "new document" handlers here.
-      ( title = (defaultText = "New Shared Directory"),
+      ( nounPhrase = (defaultText = "shared directory"),
         command = .myCommand
         # The command to run when starting for the first time. (".myCommand"
         # is just a constant defined at the bottom of the file.)


### PR DESCRIPTION
Davros currently relies on a messy hack in Sandstorm to generate the "Create new shared directory" text, as nounPhrase was implemented over eight years ago: https://github.com/sandstorm-io/sandstorm/blob/2b0bcfa0a0eec3b9b0c7de9c80161c9eb165a052/shell/imports/sandstorm-db/db.js#L2381-L2412

The comment describes a desire to remove this hack, so we should update apps which rely on it to set this. Additionally, Tempest is not supporting this legacy hack, so this patch will improve Davros support in Tempest.

We might not fix this with every package, but since Davros tends to be pretty heavily used, and there's already a few good fixes in the wings for it's next release, I wanted to get this PR open.

cc: @zenhack